### PR TITLE
Fix MCP cleanup on shutdown

### DIFF
--- a/index.js
+++ b/index.js
@@ -863,26 +863,26 @@ module.exports = {
 // Global cleanup function for process termination
 async function globalCleanup() {
   console.log('\nReceived termination signal, cleaning up...');
-  
+
   try {
-    // Clean up all MCP connections
-    if (tools.mcpClient) {
-      try {
-        const mcpModule = require('./tools/mcp/main.js');
-        console.log('Cleaning up all MCP connections...');
-        // The mcpManagers is a private Map, so we'll need to access it differently
-        // For now, just log that we're attempting cleanup
-        console.log('MCP module cleanup initiated');
-      } catch (error) {
-        console.error('Error during MCP cleanup:', error.message);
-      }
+    // Clean up resources for all known users
+    const userIds = new Set();
+    for (const key of contextManager.contexts.keys()) {
+      userIds.add(key.split('_')[0]);
     }
-    
+    if (userIds.size === 0) {
+      userIds.add('default');
+    }
+
+    for (const id of userIds) {
+      await cleanupUserResources(id);
+    }
+
     console.log('Global cleanup completed');
   } catch (error) {
     console.error('Error during global cleanup:', error.message);
   }
-  
+
   process.exit(0);
 }
 


### PR DESCRIPTION
## Summary
- call `cleanupUserResources` for all active users when the server shuts down

## Testing
- `npm test` *(fails: Connection error)*

------
https://chatgpt.com/codex/tasks/task_e_684250bb01e08322a58d0029a26cc4a8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the resource cleanup process to ensure all user resources are properly cleaned up during global cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->